### PR TITLE
Adding tiles on map

### DIFF
--- a/Backend/WorldData/Map.cs
+++ b/Backend/WorldData/Map.cs
@@ -50,7 +50,7 @@ namespace JuniorProject.Backend.WorldData
             }
         }
 
-        private int TILE_SIZE;
+        const int TILE_SIZE = 50;
         int mapHeight, mapWidth;
         Tile[,] tiles;
         public Tile getTile(int x, int y)
@@ -60,9 +60,12 @@ namespace JuniorProject.Backend.WorldData
 
         public Map()
         {
+            Debug.Print("Registering TILE_SIZE, MAP_PIXEL_WIDTH, MAP_PIXEL_HEIGHT into Client Communicator...");
+            ClientCommunicator.RegisterData<int>("TILE_SIZE", TILE_SIZE);
+            ClientCommunicator.RegisterData<int>("MAP_PIXEL_WIDTH", MAP_PIXEL_WIDTH);
+            ClientCommunicator.RegisterData<int>("MAP_PIXEL_HEIGHT", MAP_PIXEL_HEIGHT);
             Debug.Print("Loading Terrain Data...");
             LoadTerrain();
-            TILE_SIZE = ClientCommunicator.GetData<int>("TILE_SIZE");
             terrainMap = new TerrainData[MAP_PIXEL_WIDTH, MAP_PIXEL_HEIGHT];
             heightMap = new float[MAP_PIXEL_WIDTH, MAP_PIXEL_HEIGHT];
             mapWidth = MAP_PIXEL_WIDTH / TILE_SIZE;

--- a/Backend/WorldData/World.cs
+++ b/Backend/WorldData/World.cs
@@ -1,4 +1,5 @@
 ﻿
+using JuniorProject.Frontend.Components;
 using System.Drawing;
 
 namespace JuniorProject.Backend.WorldData
@@ -15,7 +16,7 @@ namespace JuniorProject.Backend.WorldData
             ClientCommunicator.RegisterAction("SaveWorld", SaveWorld);
             ClientCommunicator.RegisterData<Bitmap>("WorldImage", map.worldImage);
             ClientCommunicator.RegisterData<World>("World", map);
-
+            ClientCommunicator.RegisterData<Drawer>("Drawer", new Drawer());
 
         }
 

--- a/Frontend/Components/Drawer.cs
+++ b/Frontend/Components/Drawer.cs
@@ -9,12 +9,15 @@ namespace JuniorProject.Frontend.Components
 {
     public class Drawer
     {
-        private int TILE_SIZE;
-        const int MAP_PIXEL_WIDTH = 2000;
-        const int MAP_PIXEL_HEIGHT = 2000;
+        int TILE_SIZE;
+        int MAP_PIXEL_WIDTH;
+        int MAP_PIXEL_HEIGHT;
         public Drawer()
         {
             TILE_SIZE = ClientCommunicator.GetData<int>("TILE_SIZE");
+            MAP_PIXEL_WIDTH = ClientCommunicator.GetData<int>("MAP_PIXEL_WIDTH");
+            MAP_PIXEL_HEIGHT = ClientCommunicator.GetData<int>("MAP_PIXEL_HEIGHT");
+            Debug.Print(String.Format("Printing TILE_SIZE: {0:N}", TILE_SIZE));
         }
 
         public void Draw(Bitmap worldBitmap, ref WriteableBitmap map)

--- a/Frontend/Pages/Simulation.xaml.cs
+++ b/Frontend/Pages/Simulation.xaml.cs
@@ -22,7 +22,6 @@ namespace JuniorProject
     {
         Image mapImage;
         Drawer drawer;
-        const int TILE_SIZE = 50;
 
         private string relativePath = "LocalData\\Map.png";
         public Simulation()
@@ -31,11 +30,7 @@ namespace JuniorProject
 
             mapImage = this.Map;
 
-            Debug.Print("Registering TILE_SIZE into Client Communicator...");
-            ClientCommunicator.RegisterData<int>("TILE_SIZE", TILE_SIZE);
-
             ClientCommunicator.CallAction<IState>("SetState", new Backend.States.Simulation());
-            drawer = new Drawer();
         }
 
         private void RefreshClicked(object sender, RoutedEventArgs e)
@@ -72,6 +67,7 @@ namespace JuniorProject
 
         private WriteableBitmap ReloadImage()
         {
+            drawer = ClientCommunicator.GetData<Drawer>("Drawer");
             ClientCommunicator.CallActionWaitFor("RegenerateWorld"); //First, tell the map to regenerate the world.
             Drawing.Bitmap worldBitmap;
             worldBitmap = ClientCommunicator.GetData<Drawing.Bitmap>("WorldImage"); //Get the data from the backend


### PR DESCRIPTION
Added `Drawer` class. In the `Draw()` method, you are able to use the `Layer()` to add more to the given Bitmap from the frontend. With this, we should be able to easily draw other things on the screen, such as units or buildings :)

Took `TILE_SIZE` outside of `Map.cs` and put it in `Simulation.xaml.cs` page, which is kind of weird as I don't think the frontend should control the size of tiles, but this is the only configuration that would work, as I wanted to have a singular variable that would affect both frontend and backend `TILE_SIZE`.

How it currently looks:
![Screenshot 2025-01-29 230903](https://github.com/user-attachments/assets/855fb205-0063-4ced-ba52-57b9ae53265e)
